### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/supabase/functions/handle-email/index.ts
+++ b/supabase/functions/handle-email/index.ts
@@ -19,6 +19,19 @@ interface Source {
   updated_at: string;
 }
 
+/**
+ * Escape basic HTML entities (&, <, >, ", ')
+ * Prevents HTML/JS injection when rendering fromName
+ */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default async function handler(req: Request, supabaseClient?: any) {
   // Set CORS headers
   const corsHeaders = {
@@ -219,7 +232,7 @@ export async function processIncomingEmail(emailData: EmailData, supabase: any):
 
     const fromMatch = emailData.from.match(/<?([^<>]+@[^>\s]+)>?/);
     fromEmail = fromMatch ? fromMatch[1] : emailData.from;
-    fromName = emailData.from.replace(/<[^>]+>/g, '').trim();
+    fromName = escapeHtml(emailData.from.replace(/<[^>]+>/g, '').trim());
 
     // Assume only one recipient and resolve user strictly from DB using email_alias
     const userEmail = emailData.to.trim();


### PR DESCRIPTION
Potential fix for [https://github.com/zapidan/newsletter-hub/security/code-scanning/8](https://github.com/zapidan/newsletter-hub/security/code-scanning/8)

The best way to fix this issue is to use a well-tested sanitization library such as `sanitize-html` that removes or escapes any residual HTML tags and markup from `fromName`. However, given that we are in a Deno environment (using `https://esm.sh/`), and may not be able to introduce npm dependencies directly, the next-best fix is to perform safe HTML escaping or tag removal inline. 

For strict security, we can:
- Remove *all* HTML tags from `fromName` with a regular expression that replaces anything between `<` and `>` (e.g., `/<\/?[^>]+>/g` repeatedly until stable), or
- Perform HTML entity escaping (replace `<`, `>`, `&`, `"`, `'` with their entity equivalents).

For maximal safety (especially if the string is displayed in a web/HTML context), performing HTML entity escaping is recommended.

To implement this:
- Add an inline function to escape HTML entities (replace `<`, `>`, `&`, `"`, `'` with `&lt;`, `&gt;`, `&amp;`, `&quot;`, `&#39;`)
- Replace the sanitization on line 222 with this function.

Optionally, document the escaping function.

All changes must be made within the code shown in supabase/functions/handle-email/index.ts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
